### PR TITLE
Bugfix: child registration for TransformingGenerator1 / 2

### DIFF
--- a/src/main/java/de/galimov/datagen/transform/TransformingGenerator1.java
+++ b/src/main/java/de/galimov/datagen/transform/TransformingGenerator1.java
@@ -12,6 +12,7 @@ public class TransformingGenerator1<T, R> extends AbstractDataGenerator<R> {
     public TransformingGenerator1(DataGenerator<T> arg, Function<T, R> func) {
         this.arg = arg;
         this.func = func;
+        this.registerChildGenerator(arg);
     }
 
 

--- a/src/main/java/de/galimov/datagen/transform/TransformingGenerator2.java
+++ b/src/main/java/de/galimov/datagen/transform/TransformingGenerator2.java
@@ -14,6 +14,8 @@ public class TransformingGenerator2<T1, T2, R> extends AbstractDataGenerator<R> 
         this.arg1 = arg1;
         this.arg2 = arg2;
         this.func = func;
+        this.registerChildGenerator(arg1);
+        this.registerChildGenerator(arg2);
     }
 
     @Override


### PR DESCRIPTION
The purpose of the transforming generators is do decorate other generator(s)
with a transforming function; those other generators should be registered
as child generators, otherwise the generation cycle will not be properly
passed on. Otherwise those nested generators will always return the same
initially generated value...