### PR TITLE
Bugfix: seed values can be negative

### DIFF
--- a/src/main/java/de/galimov/datagen/basic/ObjectFromListGenerator.java
+++ b/src/main/java/de/galimov/datagen/basic/ObjectFromListGenerator.java
@@ -36,7 +36,7 @@ public class ObjectFromListGenerator<T> extends AbstractDataGenerator<T> {
     @Override
     public void setSeed(long seed) {
         super.setSeed(seed);
-        iterator = source.listIterator((int) (seed  % source.size()));
+        iterator = source.listIterator(Math.abs(seed  % source.size()));
     }
 
     @Override


### PR DESCRIPTION
Encountered an an Index out of Bounds with ObjectFromListGenerator.
Not sure if the proposed change is the best fix. But since seed values may use the full value range, it is quite likely for them to become negative